### PR TITLE
added code to get the observable state and reference trajectory in NashController

### DIFF
--- a/src/merge/nash_controller.py
+++ b/src/merge/nash_controller.py
@@ -5,6 +5,7 @@ import numpy as np
 
 
 class NashController(BaseController):
+
     def __init__(
         self,
         veh_id,
@@ -63,12 +64,253 @@ class NashController(BaseController):
         self.s1 = s1
         self.dt = dt
 
+        # Define the observable edges
+        self.observable_edges = {}
+        self.observable_edges['inflow_highway'] =   ['inflow_highway',
+                                                    ':left_0',
+                                                    'left']
+
+        self.observable_edges[':left_0'] =          ['inflow_highway',
+                                                    ':left_0',
+                                                    'left']
+
+        self.observable_edges['left'] =             ['inflow_highway',
+                                                    ':left_0',
+                                                    'left',
+                                                    ':center_1',
+                                                    'bottom',
+                                                    ':center_0']
+
+        self.observable_edges[':center_1'] =        ['left',
+                                                    ':center_1',
+                                                    'bottom',
+                                                    ':center_0',
+                                                    'center']
+
+        self.observable_edges['inflow_merge'] =     ['inflow_merge',
+                                                    ':bottom_0',
+                                                    'bottom']
+
+        self.observable_edges[':bottom_0'] =        ['inflow_merge',
+                                                    ':bottom_0',
+                                                    'bottom']
+
+        self.observable_edges['bottom'] =           ['inflow_merge',
+                                                    ':bottom_0',
+                                                    'bottom',
+                                                    ':center_0',
+                                                    'left',
+                                                    ':center_1']
+
+        self.observable_edges[':center_0'] =        ['bottom',
+                                                    ':center_0',
+                                                    'left',
+                                                    ':center_1',
+                                                    'center']
+
+        self.observable_edges['center'] =           [':center_0',
+                                                    ':center_1',
+                                                    'center']
+
     def get_accel(self, env: Env):
-        v = env.k.vehicle.get_speed(self.veh_id)
-        lead_id = env.k.vehicle.get_leader(self.veh_id)
-        h = env.k.vehicle.get_headway(self.veh_id)
+        vehicles = {}
+        for veh_id in env.sorted_ids:
+            edge = env.k.vehicle.get_edge(veh_id)
+            edge_len = env.k.scenario.edge_length(edge)
+            pos = env.k.vehicle.get_position(veh_id)
+            speed = env.k.vehicle.get_speed(veh_id)
+            vehicles[veh_id] = (edge, edge_len, pos, speed)
+
+        x0, top_merge_indices, \
+            bottom_merge_indices = self.get_observable_state(env, vehicles)
+        Xref,Uref = self.get_reference_trajectory(env, x0)
+
+        # print("Vehicle ID:", self.veh_id)
+        # print("x0=", x0)
+        # print("Top merge indices=", top_merge_indices)
+        # print("Bottom merge indices=", bottom_merge_indices)
+        # print("\n\n")
 
         # TODO: perform the optimization problem here and return the acceleration control
 
         controls = 0
         return controls
+
+    def get_observable_state(self, env, vehicles):
+        # Notes:
+        # - What other edges vehicles can observe can be configured in
+        # 'observable_edges'.
+        # - This assumes we can reach a reasonable equilibrium when each
+        # vehicle only reasons about other vehicles on nearby relevant lanes
+        # rather than having knowledge of every vehicle.
+        # - Vehicles in a merge lane should reason about all other vehicles
+        # in the connected merge lanes. However, the collision constraints
+        # should not go into effect immediately when the vehicle enters the
+        # merge lane, as this could result in an infeasible problem if two
+        # vehicles entered adjacent merge lanes at the same time.
+        # - x=0 at the merge. The position of any vehicles before the merge is
+        # negative.
+        # - Because of how FLOW defines lanes, this will only work with a merge
+        # scenario that has one highway lane and one merge lane.
+        EDGE = 0
+        EDGE_LEN = 1
+        POSITION = 2
+        SPEED = 3
+
+        # Store the edge lengths
+        inflow_highway_edge_len = env.k.scenario.edge_length('inflow_highway')
+        inflow_merge_edge_len = env.k.scenario.edge_length('inflow_merge')
+        merge_edge_len = env.k.scenario.edge_length('left')
+        center0_merge_edge_len = env.k.scenario.edge_length(':center_0')
+        center1_merge_edge_len = env.k.scenario.edge_length(':center_1')
+        bottom0_edge_len = env.k.scenario.edge_length(':bottom_0')
+        left0_edge_len = env.k.scenario.edge_length(':left_0')
+
+        assert merge_edge_len == env.k.scenario.edge_length("bottom")
+
+        edge_start_pos = {}
+        edge_start_pos['inflow_highway'] = -(center1_merge_edge_len + \
+                                             merge_edge_len + \
+                                             left0_edge_len + \
+                                             inflow_highway_edge_len)
+        edge_start_pos[':left_0'] = -(center1_merge_edge_len + \
+                                      merge_edge_len + \
+                                      left0_edge_len)
+        edge_start_pos['left'] = -(center1_merge_edge_len + merge_edge_len)
+        edge_start_pos[':center_1'] = -center1_merge_edge_len
+        edge_start_pos['inflow_merge'] = -(center0_merge_edge_len + \
+                                           merge_edge_len + \
+                                           bottom0_edge_len + \
+                                           inflow_merge_edge_len)
+        edge_start_pos[':bottom_0'] = -(center0_merge_edge_len + \
+                                        merge_edge_len + \
+                                        bottom0_edge_len)
+        edge_start_pos['bottom'] = -(center0_merge_edge_len + merge_edge_len)
+        edge_start_pos[':center_0'] = -center0_merge_edge_len
+        edge_start_pos['center'] = 0
+
+        top_merge_edges = ['left', ':center_1']
+        bottom_merge_edges = ['bottom', ':center_0']
+
+        x0 = None
+        top_merge_indices = [] # indices of vehicles on the top merge lanes
+        bottom_merge_indices = [] # indices of vehicles on the bottom merge lanes
+
+        # First handle the ego vehicle
+        ego_edge = vehicles[self.veh_id][EDGE]
+        ego_pos = vehicles[self.veh_id][POSITION] + edge_start_pos[ego_edge]
+        x0 = [ego_pos, vehicles[self.veh_id][SPEED]]
+
+        if ego_edge in top_merge_indices:
+            top_merge_indices.append(0)
+        if ego_edge in bottom_merge_indices:
+            bottom_merge_indices.append(0)
+
+        # Now handle all other vehicles
+        for key, value in vehicles.items():
+            if key == self.veh_id:
+                continue
+
+            edge = value[EDGE]
+            if edge in self.observable_edges[ego_edge]:
+                # This vehicle is on an observable edge - add its
+                # position and velocity to x0.
+                pos = value[POSITION] + edge_start_pos[edge]
+                x0.extend([pos, value[SPEED]])
+
+                vehicle_idx = len(x0)//2
+                if edge in top_merge_indices:
+                    top_merge_indices.append(vehicle_idx)
+                if edge in bottom_merge_indices:
+                    bottom_merge_indices.append(vehicle_idx)
+
+        return x0, top_merge_indices, bottom_merge_indices
+
+    @staticmethod
+    def get_dynamics_jacobians(m, dt):
+        Ak = np.array([[1., dt],
+                       [0., 1.]])
+        Bk = np.array([[0.],
+                       [dt]])
+        A = Ak
+        B = Bk
+        for k in range(1,m):
+            A = np.block([[A, np.zeros((A.shape[0],2))],
+                          [np.zeros((2,A.shape[1])), Ak]])
+            B = np.block([[B, np.zeros((B.shape[0],1))],
+                          [np.zeros((2,B.shape[1])), Bk]])
+        return A,B
+
+    def get_reference_trajectory(self, env, x0):
+        dt = 0.1
+        N = 20
+        n = len(x0)
+        m = n//2
+
+        A,B = NashController.get_dynamics_jacobians(m, dt)
+
+        Xref = [np.array(x0).reshape((n,1))]
+        Uref = [np.zeros((m,1))]
+        for k in range(1,N):
+            # Choose the controls for this time step
+            # TODO: choose a control to meet desired action (e.g. avoid
+            # collisions, accel to target speed)
+            uk = np.zeros((m,1))
+            Uref.append(uk)
+
+            # Apply dynamics
+            xk = A @ Xref[-1] + B @ Uref[-1]
+            Xref.append(xk)
+
+        Xref = np.array(Xref)
+        Uref = np.array(Uref)
+
+        return Xref, Uref
+
+    def get_action(self, env):
+        """Convert the get_accel() acceleration into an action.
+        If no acceleration is specified, the action returns a None as well,
+        signifying that sumo should control the accelerations for the current
+        time step.
+        This method also augments the controller with the desired level of
+        stochastic noise, and utlizes the "instantaneous" or "safe_velocity"
+        failsafes if requested.
+        Parameters
+        ----------
+        env : flow.envs.Env
+            state of the environment at the current time step
+        Returns
+        -------
+        float
+            the modified form of the acceleration
+        """
+        # this is to avoid abrupt decelerations when a vehicle has just entered
+        # a network and it's data is still not subscribed
+        if len(env.k.vehicle.get_edge(self.veh_id)) == 0:
+            return None
+
+        # Note: this is commented out so that we can control the vehicles in
+        # the merge junction
+        # this allows the acceleration behavior of vehicles in a junction be
+        # described by sumo instead of an explicit model
+        # if env.k.vehicle.get_edge(self.veh_id)[0] == ":":
+        #   return None
+
+        accel = self.get_accel(env)
+
+        # if no acceleration is specified, let sumo take over for the current
+        # time step
+        if accel is None:
+            return None
+
+        # add noise to the accelerations, if requested
+        if self.accel_noise > 0:
+            accel += np.random.normal(0, self.accel_noise)
+
+        # run the failsafes, if requested
+        if self.fail_safe == 'instantaneous':
+            accel = self.get_safe_action_instantaneous(env, accel)
+        elif self.fail_safe == 'safe_velocity':
+            accel = self.get_safe_velocity_action(env, accel)
+
+        return accel

--- a/src/merge_controller.ipynb
+++ b/src/merge_controller.ipynb
@@ -22,21 +22,7 @@
    "execution_count": 2,
    "id": "394d5d0f-c60e-469d-be78-625651c3d003",
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "ModuleNotFoundError",
-     "evalue": "No module named 'merge.sqp'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m                       Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-2-daee3f500a20>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mmerge\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNashController\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Documents/optimal_control_16745/OCRL-Final-Project/src/merge/__init__.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mmerge\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnlp\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNLPProblem\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mmerge\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mnash_controller\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNashController\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m~/Documents/optimal_control_16745/OCRL-Final-Project/src/merge/nash_controller.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mflow\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcontrollers\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mbase_controller\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mBaseController\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mfrom\u001b[0m \u001b[0mflow\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menvs\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mEnv\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0;32mfrom\u001b[0m \u001b[0mmerge\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msqp\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mNLPProblem\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mnumpy\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mnp\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mModuleNotFoundError\u001b[0m: No module named 'merge.sqp'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from merge import NashController "
    ]
@@ -52,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "08213651-1827-4907-97fa-2b22eadf6d25",
    "metadata": {},
    "outputs": [],
@@ -67,6 +53,32 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a63ad028",
+   "metadata": {},
+   "source": [
+    "## Set the Net Params\n",
+    "These control the configuration of the highway merge network."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "faa10d6f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Optionally adjust the net params\n",
+    "additional_net_params = ADDITIONAL_NET_PARAMS.copy()\n",
+    "additional_net_params['merge_length'] = 50 # length of the merge edge\n",
+    "additional_net_params['pre_merge_length'] = 50 # length of the highway leading to the merge\n",
+    "additional_net_params['post_merge_length'] = 100  # length of the highway past the merge\n",
+    "additional_net_params['merge_lanes'] = 1 # number of lanes in the merge\n",
+    "additional_net_params['highway_lanes'] = 1 # number of lanes in the highway\n",
+    "additional_net_params['speed_limit'] = 30 # max speed limit of the network"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "67866d3e-19f8-4947-ba11-4ea55c7496e2",
    "metadata": {},
    "source": [
@@ -75,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "9001605b-f10e-43f0-9f20-9ca5fecb1994",
    "metadata": {},
    "outputs": [],
@@ -85,55 +97,18 @@
     "# Inflow for highway lanes\n",
     "inflow.add(veh_type=\"human\",\n",
     "           edge=\"inflow_highway\",\n",
-    "           probability=0.5,\n",
-    "           depart_lane='random',  # left lane\n",
-    "           depart_speed=\"0.1\",\n",
-    "           begin=1, \n",
-    "           number=100,\n",
+    "           vehs_per_hour=10000,\n",
+    "           depart_speed=additional_net_params['speed_limit'],\n",
     "           color=\"red\")\n",
     "\n",
-    "# Inflow for right merge lane\n",
-    "inflow.add(veh_type=\"human\",\n",
-    "            edge=\"inflow_merge\",\n",
-    "            period=2,\n",
-    "            depart_lane=0,  # right lane\n",
-    "            depart_speed=0,\n",
-    "            color=\"green\")\n",
-    "\n",
-    "# Inflow for left merge lane\n",
+    "# Inflow for merge lane\n",
     "inflow.add(veh_type=\"human\",\n",
     "           edge=\"inflow_merge\",\n",
     "           probability=0.1,\n",
     "           depart_speed=\"random\",\n",
     "           begin=1, \n",
     "           number=30,\n",
-    "           color=\"blue\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "76951e0f-1ce2-4620-bb9c-5752d3db0396",
-   "metadata": {},
-   "source": [
-    "## Set the Net Params\n",
-    "These control the configuration of the highway merge network."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3a7b3785-142f-4292-a57a-a473c5f35d7d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Optionally adjust the net params\n",
-    "additional_net_params = ADDITIONAL_NET_PARAMS.copy()\n",
-    "additional_net_params['merge_length'] = 50 # length of the merge edge\n",
-    "additional_net_params['pre_merge_length'] = 50 # length of the highway leading to the merge\n",
-    "additional_net_params['post_merge_length'] = 50  # length of the highway past the merge\n",
-    "additional_net_params['merge_lanes'] = 2 # number of lanes in the merge\n",
-    "additional_net_params['highway_lanes'] = 2 # number of lanes in the highway\n",
-    "additional_net_params['speed_limit'] = 30 # max speed limit of the network\n",
+    "           color=\"blue\")\n",
     "\n",
     "net_params = NetParams(inflows=inflow,\n",
     "                       additional_params=additional_net_params)"
@@ -150,7 +125,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "951b97ff-a91b-4955-9c1c-5693f9935a50",
    "metadata": {},
    "outputs": [],
@@ -177,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "2d21f39c-4791-4baa-8da8-82b7fe43c679",
    "metadata": {},
    "outputs": [],
@@ -196,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "34035914-5cf7-4072-85b6-489853eb33ad",
    "metadata": {},
    "outputs": [],
@@ -215,13 +190,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "e40ea08e-bf12-4397-9371-e3435de65aa9",
    "metadata": {},
    "outputs": [],
    "source": [
     "# Optionally adjust the env params\n",
-    "USE_WA_ENV = True\n",
+    "USE_WA_ENV = False\n",
     "\n",
     "additional_env_params = None\n",
     "if USE_WA_ENV:\n",
@@ -255,10 +230,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "40e4431c-b9ad-41b2-85a9-53e39049de4c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "**********************************************************\n",
+      "**********************************************************\n",
+      "**********************************************************\n",
+      "WARNING: Inflows will cause computational performance to\n",
+      "significantly decrease after large number of rollouts. In \n",
+      "order to avoid this, set SumoParams(restart_instance=True).\n",
+      "**********************************************************\n",
+      "**********************************************************\n",
+      "**********************************************************\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jacob/anaconda3/envs/flow/lib/python3.6/site-packages/numpy/core/fromnumeric.py:3373: RuntimeWarning: Mean of empty slice.\n",
+      "  out=out, **kwargs)\n",
+      "/home/jacob/anaconda3/envs/flow/lib/python3.6/site-packages/numpy/core/_methods.py:170: RuntimeWarning: invalid value encountered in double_scalars\n",
+      "  ret = ret.dtype.type(ret / rcount)\n"
+     ]
+    },
+    {
+     "ename": "FatalTraCIError",
+     "evalue": "connection closed by SUMO",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFatalTraCIError\u001b[0m                           Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-11-a0db8a6c53a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0;31m# run the experiment for a set number of rollouts / time steps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m3000\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvert_to_csv\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/core/experiment.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, num_runs, num_steps, rl_actions, convert_to_csv)\u001b[0m\n\u001b[1;32m    118\u001b[0m             \u001b[0mstate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menv\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0mj\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnum_steps\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 120\u001b[0;31m                 \u001b[0mstate\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreward\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menv\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrl_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    121\u001b[0m                 vel[j] = np.mean(\n\u001b[1;32m    122\u001b[0m                     self.env.k.vehicle.get_speed(self.env.k.vehicle.get_ids()))\n",
+      "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/envs/base_env.py\u001b[0m in \u001b[0;36mstep\u001b[0;34m(self, rl_actions)\u001b[0m\n\u001b[1;32m    350\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    351\u001b[0m             \u001b[0;31m# advance the simulation in the simulator by one step\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 352\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation_step\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    353\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    354\u001b[0m             \u001b[0;31m# store new observations in the vehicles and traffic lights class\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/core/kernel/simulation/traci.py\u001b[0m in \u001b[0;36msimulation_step\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     54\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msimulation_step\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     55\u001b[0m         \u001b[0;34m\"\"\"See parent class.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 56\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel_api\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulationStep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     57\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     58\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mupdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/flow/lib/python3.6/site-packages/traci/connection.py\u001b[0m in \u001b[0;36msimulationStep\u001b[0;34m(self, step)\u001b[0m\n\u001b[1;32m    321\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_queue\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCMD_SIMSTEP\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    322\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_string\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0mstruct\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpack\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"!BBd\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m1\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m1\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0;36m8\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mtc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mCMD_SIMSTEP\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstep\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 323\u001b[0;31m         \u001b[0mresult\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sendExact\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    324\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0msubscriptionResults\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_subscriptionMapping\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    325\u001b[0m             \u001b[0msubscriptionResults\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/anaconda3/envs/flow/lib/python3.6/site-packages/traci/connection.py\u001b[0m in \u001b[0;36m_sendExact\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     97\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_socket\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     98\u001b[0m             \u001b[0;32mdel\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_socket\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 99\u001b[0;31m             \u001b[0;32mraise\u001b[0m \u001b[0mFatalTraCIError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"connection closed by SUMO\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    100\u001b[0m         \u001b[0;32mfor\u001b[0m \u001b[0mcommand\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_queue\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    101\u001b[0m             \u001b[0mprefix\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"!BBB\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFatalTraCIError\u001b[0m: connection closed by SUMO"
+     ]
+    }
+   ],
    "source": [
     "# create the scenario object\n",
     "scenario = MergeScenario(name=\"merge_example\",\n",
@@ -294,13 +311,17 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": null,
+   "lastKernelId": null
+  },
   "interpreter": {
    "hash": "56969b528e345da22d593b50d4ae1ccac09b4d05286ce64bd33b0588e7741df1"
   },
   "kernelspec": {
    "display_name": "flow",
    "language": "python",
-   "name": "python3"
+   "name": "flow"
   },
   "language_info": {
    "codemirror_mode": {

--- a/src/merge_controller.ipynb
+++ b/src/merge_controller.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "id": "e7ba4445-e3bb-45c7-8234-58a85462eb05",
    "metadata": {},
    "outputs": [],
@@ -19,7 +19,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 13,
    "id": "394d5d0f-c60e-469d-be78-625651c3d003",
    "metadata": {},
    "outputs": [],
@@ -38,7 +38,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 14,
    "id": "08213651-1827-4907-97fa-2b22eadf6d25",
    "metadata": {},
    "outputs": [],
@@ -53,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a63ad028",
+   "id": "7263b650",
    "metadata": {},
    "source": [
     "## Set the Net Params\n",
@@ -62,8 +62,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "faa10d6f",
+   "execution_count": 15,
+   "id": "f0a96d79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +87,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 16,
    "id": "9001605b-f10e-43f0-9f20-9ca5fecb1994",
    "metadata": {},
    "outputs": [],
@@ -97,7 +97,9 @@
     "# Inflow for highway lanes\n",
     "inflow.add(veh_type=\"human\",\n",
     "           edge=\"inflow_highway\",\n",
-    "           vehs_per_hour=10000,\n",
+    "           probability=0.5,\n",
+    "           begin=1,\n",
+    "           number=100,\n",
     "           depart_speed=additional_net_params['speed_limit'],\n",
     "           color=\"red\")\n",
     "\n",
@@ -125,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 17,
    "id": "951b97ff-a91b-4955-9c1c-5693f9935a50",
    "metadata": {},
    "outputs": [],
@@ -152,7 +154,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 18,
    "id": "2d21f39c-4791-4baa-8da8-82b7fe43c679",
    "metadata": {},
    "outputs": [],
@@ -171,7 +173,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "34035914-5cf7-4072-85b6-489853eb33ad",
    "metadata": {},
    "outputs": [],
@@ -190,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "id": "e40ea08e-bf12-4397-9371-e3435de65aa9",
    "metadata": {},
    "outputs": [],
@@ -230,7 +232,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 22,
    "id": "40e4431c-b9ad-41b2-85a9-53e39049de4c",
    "metadata": {},
    "outputs": [
@@ -266,7 +268,7 @@
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
       "\u001b[0;31mFatalTraCIError\u001b[0m                           Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-11-a0db8a6c53a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0;31m# run the experiment for a set number of rollouts / time steps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m3000\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvert_to_csv\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-22-a0db8a6c53a7>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     18\u001b[0m \u001b[0;31m# run the experiment for a set number of rollouts / time steps\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 19\u001b[0;31m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mexp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m3000\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mconvert_to_csv\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
       "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/core/experiment.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, num_runs, num_steps, rl_actions, convert_to_csv)\u001b[0m\n\u001b[1;32m    118\u001b[0m             \u001b[0mstate\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menv\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0mj\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mnum_steps\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 120\u001b[0;31m                 \u001b[0mstate\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreward\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0menv\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mrl_actions\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    121\u001b[0m                 vel[j] = np.mean(\n\u001b[1;32m    122\u001b[0m                     self.env.k.vehicle.get_speed(self.env.k.vehicle.get_ids()))\n",
       "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/envs/base_env.py\u001b[0m in \u001b[0;36mstep\u001b[0;34m(self, rl_actions)\u001b[0m\n\u001b[1;32m    350\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    351\u001b[0m             \u001b[0;31m# advance the simulation in the simulator by one step\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 352\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulation_step\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    353\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    354\u001b[0m             \u001b[0;31m# store new observations in the vehicles and traffic lights class\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
       "\u001b[0;32m~/cmu/16745/OCRL-Final-Project/flow/core/kernel/simulation/traci.py\u001b[0m in \u001b[0;36msimulation_step\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     54\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0msimulation_step\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     55\u001b[0m         \u001b[0;34m\"\"\"See parent class.\"\"\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 56\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkernel_api\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msimulationStep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     57\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     58\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mupdate\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mreset\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",


### PR DESCRIPTION
See the image below for how FLOW defines the lanes. I set up the code such that each vehicle only includes other vehicles that are on observable edges, as defined by 'observable_edges' in NashController. We can always change this to be fully observable if we find it isn't working well, but hopefully this still works and allows the controller to run much faster.

The other point to note that influenced why I set things up the way I did is that, because we are treating this as a 1D problem in which the vehicles are always in the center of their lanes, we need to be careful how/when we setup collision constraints in the merge. I am keeping track of the indices of the vehicles that are on the edges approaching the merge so that we can use them when we setup the collision constraints. If we simply activated the constraints as soon the vehicles were on these merge edges, it could result in an infeasible problem in the case that two vehicles were the same distance from the merge (i.e. their x positions are close to each other). We'll have to do some sort of ramp up in the tolerance for the collision constraint as the vehicles approach the merge to address this.

![Drawing (1)](https://user-images.githubusercontent.com/25355823/163893097-07b322cd-f12e-4335-8a1f-a95e4fcbbb58.png)
